### PR TITLE
Fix possible hats typos, comment other proposals

### DIFF
--- a/xep-0317.xml
+++ b/xep-0317.xml
@@ -105,64 +105,6 @@
 
 <p>If the requesting entity detects that, based on a mismatching hash, the localy stored hats list is considered outdated.</p>
 
-  <section2 topic='Listing Hats'>
-    <p>An entity might be interested to get all the existing hats available in a chatroom.</p>
-
-    <example caption='User’s client request the hats list configured on a MUC room'><![CDATA[
-<iq from='professor@example.edu/office'
-  id='fdi3n2b6'
-  to='physicsforpoets@courses.example.edu'
-  type='set'
-  xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-          action='execute'
-          node='urn:xmpp:hats:commands:list'/>
-</iq>]]></example>
-    <example caption='Room returns the list of configured hats'><![CDATA[
-<iq from='physicsforpoets@courses.example.edu'
-    id='fdi3n2b6'
-    to='professor@example.edu/office'
-    type='result'
-    xml:lang='en'>
-  <command xmlns='http://jabber.org/protocol/commands'
-           node='urn:xmpp:hats:commands:list'
-           status='completed'
-           sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
-    <x xmlns='jabber:x:data' type='result'>
-      <title>Hats List</title>
-      <reported>
-        <field var='hats#title'/>
-        <field var='hats#uri'/>
-        <field var='hats#hue'/>
-      </reported>
-      <item>
-        <field var='hats#title'>
-            <value>Host</value>
-        </field>
-        <field var='hats#uri'>
-            <value>http://schemas.example.com/hats#host</value>
-        </field>
-        <field var='hats#hue'>
-            <value>327.255249</value>
-        </field>
-      </item>
-      <item>
-        <field var='hats#title'>
-            <value>Presenter</value>
-        </field>
-        <field var='hats#uri'>
-            <value>http://schemas.example.com/hats#presenter</value>
-        </field>
-        <field var='hats#hue'>
-            <value>171.430664</value>
-        </field>
-      </item>
-      …
-    </x>
-  </command>
-</iq>
-]]></example>
-  </section2>
 </section1>
 
 <section1 topic='Protocol' anchor='protocol'>
@@ -298,8 +240,48 @@
   </section2>
   <section2 topic='Destroying a Hat' anchor='destroy'>
     <p>The following flow shows how to destroy a hat and remove it from the list of available hats.</p>
+    <p>It first asks the formulary, which returns a list of all the available hats, and then actually requests to destroy one of them. Notice that alternatively, the client may send directly the query to destroy a hat without first requesting the formulary, as it already knows many hats that were received in presence stanzas.</p>
     <p>When a hat is destroyed, it is automatically removed from all the JIDs where it was assigned.</p>
     <p>The room SHOULD broadcast the related JID presences with the refreshed hats list.</p>
+    <example caption='Admin Requests Form to Destroy a Hat'><![CDATA[
+<iq from='professor@example.edu/office'
+    id='gd53a2b6'
+    to='physicsforpoets@courses.example.edu'
+    type='set'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           action='execute'
+           node='urn:xmpp:hats:commands:destroy'>
+  </command>
+</iq>
+]]></example>
+    <example caption='Room Provides Form to Destroy a Hat'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='gd53a2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+            node='urn:xmpp:hats:commands:destroy'
+            sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'
+            status='executing'>
+    <x xmlns='jabber:x:data' type='form'>
+      <title>Destroying a Hat</title>
+      <instructions>Fill out this form to destroy a hat.</instructions>
+      <field type='hidden' var='FORM_TYPE'>
+        <value>urn:xmpp:hats:commands</value>
+      </field>
+      <field label='The role'
+             type='list-single'
+             var='hat'>
+        <option label='Teacher'><value>http://tech.example.edu/hats#Teacher</value></option>
+        <option label='Teacher&apos;s Assistant'><value>http://tech.example.edu/hats#TeacherAssistant</value></option>
+        <option label='Test Proctor'><value>http://tech.example.edu/hats#Proctor</value></option>
+      </field>
+    </x>
+  </command>
+</iq>
+]]></example>
     <example caption='Admin Requests to Destroy a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='rei4n2b0'
@@ -330,6 +312,63 @@
            node='urn:xmpp:hats:commands:destroy'
            sessionid='A971D19A-2226-4DAD-B261-7D0886B9A123'
            status='completed'/>
+</iq>
+]]></example>
+  </section2>
+  <section2 topic='Listing Hats'>
+    <p>An entity might be interested to get all the existing hats available in a chatroom.</p>
+    <example caption='User’s client request the hats list configured on a MUC room'><![CDATA[
+<iq from='professor@example.edu/office'
+  id='fdi3n2b6'
+  to='physicsforpoets@courses.example.edu'
+  type='set'
+  xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+          action='execute'
+          node='urn:xmpp:hats:commands:list'/>
+</iq>]]></example>
+    <example caption='Room Returns the List of Configured Hats'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='fdi3n2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:list'
+           status='completed'
+           sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='result'>
+      <title>Hats List</title>
+      <reported>
+        <field var='hats#title'/>
+        <field var='hats#uri'/>
+        <field var='hats#hue'/>
+      </reported>
+      <item>
+        <field var='hats#title'>
+            <value>Host</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://schemas.example.com/hats#host</value>
+        </field>
+        <field var='hats#hue'>
+            <value>327.255249</value>
+        </field>
+      </item>
+      <item>
+        <field var='hats#title'>
+            <value>Presenter</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://schemas.example.com/hats#presenter</value>
+        </field>
+        <field var='hats#hue'>
+            <value>171.430664</value>
+        </field>
+      </item>
+      …
+    </x>
+  </command>
 </iq>
 ]]></example>
   </section2>
@@ -453,6 +492,58 @@
            node='urn:xmpp:hats:commands:unassign'
            sessionid='A971D19A-2226-4DAD-B261-8D0886B9A026'
            status='completed'/>
+</iq>
+]]></example>
+  </section2>
+
+  <section2 topic='Listing Assigned Hats'>
+    <p>An entity might be interested to get all the hats assigned to users in a chatroom.</p>
+
+    <example caption='User’s client request the hats list assigned on a MUC room'><![CDATA[
+<iq from='professor@example.edu/office'
+  id='fdi3n2b6'
+  to='physicsforpoets@courses.example.edu'
+  type='set'
+  xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+          action='execute'
+          node='urn:xmpp:hats:commands:list-assigned'/>
+</iq>]]></example>
+    <example caption='Room Returns the List of Assigned Hats'><![CDATA[
+<iq from='physicsforpoets@courses.example.edu'
+    id='fdi3n2b6'
+    to='professor@example.edu/office'
+    type='result'
+    xml:lang='en'>
+  <command xmlns='http://jabber.org/protocol/commands'
+           node='urn:xmpp:hats:commands:list-assigned'
+           status='completed'
+           sessionid='A971D19A-2226-4DAD-B261-9D0886B9A026'>
+    <x xmlns='jabber:x:data' type='result'>
+      <title>Assigned Hats List</title>
+      <reported>
+        <field var='hats#jid'/>
+        <field var='hats#uri'/>
+        <field var='hats#title'/>
+        <field var='hats#hue'/>
+      </reported>
+      <item>
+        <field var='hats#jid'>
+            <value>terry.anderson@example.edu</value>
+        </field>
+        <field var='hats#uri'>
+            <value>http://tech.example.edu/hats#TeacherAssistant</value>
+        </field>
+        <field var='hats#title'>
+            <value>Assistant</value>
+        </field>
+        <field var='hats#hue'>
+            <value>327.255249</value>
+        </field>
+      </item>
+      …
+    </x>
+  </command>
 </iq>
 ]]></example>
   </section2>

--- a/xep-0317.xml
+++ b/xep-0317.xml
@@ -63,24 +63,24 @@
 </section1>
 
 <section1 topic='Discovery' anchor='disco'>
-  <p>A MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0" to the requesting entity.</p>
+  <p>A room in a MUC service that supports hats MUST advertise a &xep0030; feature of "urn:xmpp:hats:0" to the requesting entity.</p>
 
   <p>The "hat list" and all associated commands are OPTIONAL. Some of the commands might be restricted by some business logic or internal rules (such as a LDAP configuration where the hats are already preconfigured).</p>
 
   <p>If the room has a list of hats configured, it should advertise it in its 'muc#roominfo' extension form by computing a unique hash based on the list of hats URIs provided. The way the hash is computed is left to the implementer.</p>
 
-  <example caption='User’s client discovers the hat features of a MUC service'><![CDATA[
-<iq type='get'
+  <example caption='User’s client discovers the hat features of a MUC room'><![CDATA[
+<iq from='professor@example.edu/office'
     id='p87Ne'
-    from='romeo@montague.example.net/garden'
-    to='physicsforpoets@courses.example.edu'>
+    to='physicsforpoets@courses.example.edu'
+    type='get'>
   <query xmlns='http://jabber.org/protocol/disco#info'/>
 </iq>]]></example>
     <example caption='Room advertises hats support'><![CDATA[
-<iq type='result'
+<iq from='physicsforpoets@courses.example.edu'
     id='p87Ne'
-    to='romeo@montague.example.net/garden'
-    from='physicsforpoets@courses.example.edu'>
+    to='professor@example.edu/office'
+    type='result'>
   <query xmlns='http://jabber.org/protocol/disco#info'>
     <identity
         category='conference'
@@ -108,7 +108,7 @@
   <section2 topic='Listing Hats'>
     <p>An entity might be interested to get all the existing hats available in a chatroom.</p>
 
-    <example caption='User’s client request the hats list configured on a MUC service'><![CDATA[
+    <example caption='User’s client request the hats list configured on a MUC room'><![CDATA[
 <iq from='professor@example.edu/office'
   id='fdi3n2b6'
   to='physicsforpoets@courses.example.edu'
@@ -118,7 +118,7 @@
           action='execute'
           node='urn:xmpp:hats:commands:list'/>
 </iq>]]></example>
-    <example caption='Service returns the list of configured hats'><![CDATA[
+    <example caption='Room returns the list of configured hats'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'
@@ -193,7 +193,7 @@
   <section2 topic='Creating and Updating a Hat' anchor='create'>
     <p>Hats are created and destroyed using &xep0050;.</p>
     <p>The following flow shows how to create a hat.</p>
-    <p>Updating a hat follows the same flow but set an existing "hats#uri". If a hat is updated the service SHOULD broadcast the related JID presences with the refreshed hat list.</p>
+    <p>Updating a hat follows the same flow but set an existing "hats#uri". If a hat is updated the room SHOULD broadcast the related JID presences with the refreshed hat list.</p>
     <example caption='Admin Requests to Create a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='gd53a2b6'
@@ -206,7 +206,7 @@
 </iq>
 ]]></example>
 
-    <example caption='Service Returns Form to Admin'><![CDATA[
+    <example caption='Room Returns Form to Admin'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='gd53a2b6'
     to='professor@example.edu/office'
@@ -224,7 +224,7 @@
       </field>
       <field var='hats#title'
             type='text-single'
-            label='Hat title'>
+            label='Hat Title'>
         <required/>
       </field>
       <field var='hats#uri'
@@ -265,7 +265,7 @@
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='9fets723'
     to='professor@example.edu/office'
@@ -277,7 +277,7 @@
             status='completed'/>
 </iq>
 ]]></example>
-  <p>When any change is applied to the hats list the room should SHOULD broadcast a notification that the configuration changed to all users present.</p>
+  <p>When any change is applied to the hats list the room SHOULD broadcast a notification that the configuration changed to all users present.</p>
   <example caption='Room broadcasts a configuration change'><![CDATA[
 <message type='groupchat'
       to='professor@example.edu/office'
@@ -299,7 +299,7 @@
   <section2 topic='Destroying a Hat' anchor='destroy'>
     <p>The following flow shows how to destroy a hat and remove it from the list of available hats.</p>
     <p>When a hat is destroyed, it is automatically removed from all the JIDs where it was assigned.</p>
-    <p>The service SHOULD broadcast the related JID presences with the refreshed hats list.</p>
+    <p>The room SHOULD broadcast the related JID presences with the refreshed hats list.</p>
     <example caption='Admin Requests to Destroy a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='rei4n2b0'
@@ -313,14 +313,14 @@
       <field type='hidden' var='FORM_TYPE'>
         <value>urn:xmpp:hats:commands</value>
       </field>
-      <field var='hat'>
+      <field var='hats#uri'>
         <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='rei4n2b0'
     to='professor@example.edu/office'
@@ -347,8 +347,8 @@
            node='urn:xmpp:hats:commands:assign'/>
 </iq>
 ]]></example>
-    <p>Unless an error occurs, the service returns the appropriate form.</p>
-    <example caption='Service Returns Form to Admin'><![CDATA[
+    <p>Unless an error occurs, the room returns the appropriate form.</p>
+    <example caption='Room Returns Form to Admin'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'
@@ -371,7 +371,7 @@
       </field>
       <field label='The role'
              type='list-single'
-             var='hat'>
+             var='hats#uri'>
         <option label='Teacher'><value>http://tech.example.edu/hats#Teacher</value></option>
         <option label='Teacher&apos;s Assistant'><value>http://tech.example.edu/hats#TeacherAssistant</value></option>
         <option label='Test Proctor'><value>http://tech.example.edu/hats#Proctor</value></option>
@@ -396,14 +396,14 @@
       <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
-      <field var='hat'>
+      <field var='hats#uri'>
         <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='9fens61z'
     to='professor@example.edu/office'
@@ -419,7 +419,7 @@
   </section2>
   <section2 topic='Removing a Hat' anchor='remove'>
     <p>The following flow shows how to remove a hat.</p>
-    <p>When the hat is removed service SHOULD broadcast the related JID presence with the refreshed hat list.</p>
+    <p>When the hat is removed, the room SHOULD broadcast the related JID presence with the refreshed hat list.</p>
     <example caption='Admin Requests to Remove a Hat'><![CDATA[
 <iq from='professor@example.edu/office'
     id='fdi3n2b6'
@@ -436,14 +436,14 @@
       <field var='hats#jid'>
         <value>terry.anderson@example.edu</value>
       </field>
-      <field var='hat'>
+      <field var='hats#uri'>
         <value>http://tech.example.edu/hats#TeacherAssistant</value>
       </field>
     </x>
   </command>
 </iq>
 ]]></example>
-    <example caption='Service Informs Admin of Completion'><![CDATA[
+    <example caption='Room Informs Admin of Completion'><![CDATA[
 <iq from='physicsforpoets@courses.example.edu'
     id='fdi3n2b6'
     to='professor@example.edu/office'


### PR DESCRIPTION
I'm implementing Hats 0.3.0 in ejabberd, and I've noticed some incoherences in the XEP. As I imagine they are not intended, this PR includes those changes to open discussion:

- Say "room" instead of "service" when the action deals with a specific room
- In Example 1, instead of Romeo, use the same User JID than the other examples
- In Example 1, sort attributes
- Fix capitalization of "Hat title" label
- In examples, use the defined field var "hats#uri" instead of ambiguous "hat"

---

Other proposals that I'm thinking about, but are not included in this PR:

### Destroy Hat

When destroying a hat, right now it asks the hat URI. However, as it is only possible to destroy a hat that already exists, the formulary offered by the server could instead provide the list of hats, then the client picks one of them to destroy.

This would be similar to the formulary to assign a hat to a user.

### Move 2.1

I would say that "2.1 Listing Hats" should be moved down to section "3. Protocol"

### List Assigned Hats

And finally, that XEP still does not provide any way to list the **assigned** hats, as described in [ejabberd custom XEP List Hats](https://docs.ejabberd.im/tutorials/muc-hats/#admin-requests-to-list-hats). Maybe that feature is not really needed in practice by clients? 

If it were needed, then the XEP could get another command: "List Assigned Hats", which returns a list of `{hats#jid, hats#uri}` that are assigned in the room
